### PR TITLE
Check required labels on PRs

### DIFF
--- a/.github/workflows/required_pr-label-for-develop.yml
+++ b/.github/workflows/required_pr-label-for-develop.yml
@@ -1,0 +1,21 @@
+name: Required PR Labels for Develop
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types: [opened, synchronize, reopened, labeled, unlabeled, review_requested, ready_for_review]
+
+jobs:
+  label:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check required labels
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          has_required_label=$(echo "$LABELS" | jq 'map(select(. | contains("type:Feature") or contains("type:Bugfix") or contains("type:Task"))) | length')
+          if [[ $has_required_label -ne 1 ]]; then
+            echo "Pull request must have one of the following labels: type:Feature, type:Bugfix, type:Task."
+            exit 1
+          fi    

--- a/.github/workflows/required_pr-label-for-main.yml
+++ b/.github/workflows/required_pr-label-for-main.yml
@@ -1,0 +1,21 @@
+name: Required PR Labels for Main
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, labeled, unlabeled, review_requested, ready_for_review]
+
+jobs:
+  label:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check required labels
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          has_required_label=$(echo "$LABELS" | jq 'map(select(. | contains("type:Release"))) | length')
+          if [[ $has_required_label -ne 1 ]]; then
+            echo "Pull request must have the following label: type:Release."
+            exit 1
+          fi    


### PR DESCRIPTION
It is a challenge to check required labels on PRs without using https://github.com/mheap/github-action-required-labels as follows:

```yml
name: Required Pull Request Labels

on:
  pull_request:
    branches:
      - develop
    types: [opened, synchronize, reopened, labeled, unlabeled, review_requested, ready_for_review]

jobs:
  label:
    runs-on: ubuntu-22.04
    permissions:
      pull-requests: read
    steps:
      - uses: mheap/github-action-required-labels@cc7a79fadbba6ed1d6f0efd70707e7b8bf7e6910 # v5.2.0
        with:
          mode: exactly
          count: 1
          labels: "type:Feature, type:Bugfix, type:Task"
```